### PR TITLE
Adding blockly examples

### DIFF
--- a/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/settings.json
+++ b/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/settings.json
@@ -1,0 +1,120 @@
+{
+    "title": "Softata Visual API",
+    "footer": "Please give us a star on https://github.com/ignatandrei/BlocklyAutomation",
+    "localAPI": "http://localhost:37283/",
+    "startBlocks":[
+
+"      <xml xmlns='https://developers.google.com/blockly/xml'>",
+"      <block type='text_print' x='181' y='254'>",
+"        <value name='TEXT'>",
+"          <block type='post__Connect'>",
+"            <value name='val_ipAddress'>",
+"              <block type='text'>",
+"                <field name='TEXT'>192.168.0.9</field>",
+"              </block>",
+"            </value>",
+"            <value name='val__port'>",
+"              <block type='math_number'>",
+"                <field name='NUM'>4242</field>",
+"              </block>",
+"            </value>",
+"            <value name='override_Host'>",
+"              <block type='text'>",
+"                <field name='TEXT'> </field>",
+"              </block>",
+"            </value>",
+"            <value name='override_Port'>",
+"              <block type='math_number'>",
+"                <field name='NUM'>0</field>",
+"              </block>",
+"            </value>",
+"          </block>",
+"        </value>",
+"        <next>",
+"          <block type='text_print'>",
+"            <value name='TEXT'>",
+"              <block type='post__Display_Clear'>",
+"                <value name='val_displayLinkedListIndex'>",
+"                  <block type='math_number'>",
+"                    <field name='NUM'>0</field>",
+"                  </block>",
+"                </value>",
+"                <value name='override_Host'>",
+"                  <block type='text'>",
+"                    <field name='TEXT'> </field>",
+"                  </block>",
+"                </value>",
+"                <value name='override_Port'>",
+"                  <block type='math_number'>",
+"                    <field name='NUM'>0</field>",
+"                  </block>",
+"                </value>",
+"              </block>",
+"            </value>",
+"          </block>",
+"        </next>",
+"      </block>",
+"    </xml>",
+""
+      
+    ],
+    "hideMenu":false,
+  "tourSteps":
+    [
+      {
+          "text":"This is the  help tour",
+          "query":".blocklyWorkspace"          
+      },
+      {
+        "text": "You can start with help first",
+        "query":".btnHelp"
+      },
+      {
+        "text":"Here you can find blocks for VisualCode  API ! Expand to investigate and drag",
+        "query":".blocklyToolboxContents"
+      },
+      
+      {
+        "text":"Here you can find blocks for basic constructs : loops, text, bool, logic ...",
+        "query":".blocklyTreeLabel"
+      }
+      ,
+      
+      {
+        "text":"If you are a programmer, you can find your swagger at the left -we have package for Java, .NET , Node, PHP <a href='https://github.com/ignatandrei/blocklyautomation' target='_blank'>VisualAPI</a>",
+        "query":""
+      },
+      
+      {
+        "text":"Drag here blocks to execute them",
+        "query":".blocklyBlockCanvas"
+      }
+      ,
+      {
+          "text":"Here you will find examples to get started",
+          "query":".stepTourDemos"
+      },
+      {
+          "text":"to reuse you can download / load  the blocks from here",
+          "query":".stepTourDownload"
+      },
+      {
+          "text":"Press the execute button to run ;-) ",
+          "query":".stepTourRunButton"
+      },
+      
+      {
+          "text":"Press the output button to see the result of blocks",
+          "query":".stepTourOutputButton"
+      }
+      ,{
+        "text":"Here you can find the output as text, html and json",
+        "query":".stepTourOutput"
+      },
+      {
+          "text":"Now press execute and see , via HTTP, a joke with Chuck Norris ",
+          "query":".stepTourRunButton"
+      }
+      
+  ]
+}

--- a/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/demoBlocks/all.txt
+++ b/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/demoBlocks/all.txt
@@ -1,0 +1,8 @@
+﻿[
+    {
+        "id":  "startExample",
+        "description":  "Softatat Start Example",
+        "categories":  "api;list",
+        "blocks":  "object_create;text;"
+    }
+]

--- a/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/demoBlocks/startExample.txt
+++ b/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/demoBlocks/startExample.txt
@@ -1,0 +1,51 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="text_print" x="181" y="254">
+    <value name="TEXT">
+      <block type="post__Connect">
+        <value name="val_ipAddress">
+          <block type="text">
+            <field name="TEXT">192.168.0.9</field>
+          </block>
+        </value>
+        <value name="val__port">
+          <block type="math_number">
+            <field name="NUM">4242</field>
+          </block>
+        </value>
+        <value name="override_Host">
+          <block type="text">
+            <field name="TEXT"> </field>
+          </block>
+        </value>
+        <value name="override_Port">
+          <block type="math_number">
+            <field name="NUM">0</field>
+          </block>
+        </value>
+      </block>
+    </value>
+    <next>
+      <block type="text_print">
+        <value name="TEXT">
+          <block type="get__Display_GetPins">
+            <value name="val_idisplay">
+              <block type="math_number">
+                <field name="NUM">0</field>
+              </block>
+            </value>
+            <value name="override_Host">
+              <block type="text">
+                <field name="TEXT"> </field>
+              </block>
+            </value>
+            <value name="override_Port">
+              <block type="math_number">
+                <field name="NUM">0</field>
+              </block>
+            </value>
+          </block>
+        </value>
+      </block>
+    </next>
+  </block>
+</xml>

--- a/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/findBlocks.ps1
+++ b/SoftataWebAPI/wwwroot/BlocklyAutomation/assets/showUsage/findBlocks.ps1
@@ -1,0 +1,21 @@
+cls
+cd demoBlocks
+$content = Get-Content -Path All.txt | ConvertFrom-Json 
+
+foreach($val in $content  ) {
+
+$file = $val.Id + ".txt" 
+
+Write-Host 'process' $file 
+$fileContent = [XML](Get-Content -Path $file)
+$blocks = $fileContent.SelectNodes("//*[local-name () = 'block']") | Select -Unique  -ExpandProperty type  | Where { $_.StartsWith("variables") -eq $false }
+$str =[String]::Join(';',$blocks)
+
+
+$val | add-member -Name "blocks" -value $str -MemberType NoteProperty -Force
+
+
+
+}
+
+$content | ConvertTo-Json | Out-File "All.txt" -Encoding utf8


### PR DESCRIPTION
I have added how to put your Soft-Ata API when Blockly shows and how to add more examples.
Please start the project and see how 
1. You have an example with Soft-Ata API ( press examples button)
2. The startup blocks are modified with Soft-Ata API blocks


1. In order to add more examples:

Create your example ( with more blocks ) . Press "download blocks"
![image](https://github.com/djaus2/Soft-ata/assets/153982/d754359e-682d-4b96-a2f8-651079a5744c)

Save the text file into SoftataWebAPI\wwwroot\BlocklyAutomation\assets\showUsage folder (near SoftataWebAPI\wwwroot\BlocklyAutomation\assets\showUsage\demoBlocks )
Modify all.txt file by adding 
{
        "id":  "your text file name without .txt",
        "description":  "Your description",
        "categories":  "api;list;whatever",
        "blocks":  "object_create;text;whenever"
    }
 

2. To modify the opening blocks, repeat 1 and have the .txt file . Modify in the .txt file double quotes with single quotes ( " with '  ) 
Modify file SoftataWebAPI\wwwroot\BlocklyAutomation\assets\settings.json by putting into startBlocks array with each line starting with 
" 
and ending with 
",

( without last line )  